### PR TITLE
Remove Ingress whitelisting because it is surplus as IP restrictions …

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -14,7 +14,6 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     certmanager.k8s.io/cluster-issuer: letsencrypt-production
-    nginx.ingress.kubernetes.io/whitelist-source-range: "217.33.148.210/32,81.134.202.29/32,52.56.175.16/32,35.177.252.195/32"
   hosts:
     - host: dev.devtest.assessment-api.hmpps.dsd.io
       cert_secret: tls-secret

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,7 +14,6 @@ ingress:
   enabled: true
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/whitelist-source-range: "217.33.148.210/32,81.134.202.29/32,52.56.175.16/32,35.177.252.195/32"
   hosts:
     - host: preprod.assessment-api.hmpps.dsd.io
       cert_secret: assessment-api-cert

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -13,7 +13,6 @@ ingress:
   enabled: true
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/whitelist-source-range: "217.33.148.210/32,81.134.202.29/32,52.56.175.16/32,35.177.252.195/32"
   hosts:
     - host: assessment-api.hmpps.dsd.io
       cert_secret: assessment-api-cert


### PR DESCRIPTION
…are in place  at the NSG (layer 3) and so traffic will never reach the ingress controller.